### PR TITLE
Fix the linting docs

### DIFF
--- a/docs/frontend/linting.md
+++ b/docs/frontend/linting.md
@@ -62,14 +62,16 @@ In order to have VSCode propery use these linting things, add these settings
 to your config:
 
 ```json
-// These are all my auto-save configs
-"editor.formatOnSave": true,
+// Turn off vs code formatting
+"editor.formatOnSave": false,
 // turn it off for JS and JSX, we will do this via eslint
 "[javascript]": {
   "editor.formatOnSave": false
 },
 // tell the ESLint plugin to run on save
-"eslint.autoFixOnSave": true
+"editor.codeActionsOnSave": {
+  "source.fixAll.eslint": true
+}
 ```
 
 A good ressource for more info concerning prettier + vscode is


### PR DESCRIPTION
The settings for the linting have been changed with a new VS code
release. Updating to that

# Checklist (Only for frontend changes)
- [ ] Changes tested in IE11
- [ ] Responsive
- [ ] Documented "How to use it"
- [ ] Documented "How to install"
- [ ] Featured in Styleguide

# Summary of this PR
