### PR TITLE
fix: use email for user creation form in backend

### DIFF
--- a/backend/accounts/admin.py
+++ b/backend/accounts/admin.py
@@ -11,7 +11,11 @@ class UserAdmin(BaseUserAdmin):
     ordering = ('email',)
     list_display = ('email', 'first_name', 'last_name', 'is_active')
     search_fields = ['first_name', 'last_name', 'email']
-
+    add_fieldsets = (
+        ('Account', {
+            'fields': ('email', 'password1', 'password2',)
+        }),
+    )
     fieldsets = (
         ('Account', {
             'fields': ('email', 'password', 'first_name', 'last_name')


### PR DESCRIPTION
#82 Summary of this PR
In the user creation form in the backend, use the email instead of the username to register an user