### PR TITLE
Install tabbable, a dependency of focus trap

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7712,15 +7712,6 @@
         }
       }
     },
-    "focus-trap": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-5.1.0.tgz",
-      "integrity": "sha512-CkB/nrO55069QAUjWFBpX6oc+9V90Qhgpe6fBWApzruMq5gnlh90Oo7iSSDK7pKiV5ugG6OY2AXM5mxcmL3lwQ==",
-      "requires": {
-        "tabbable": "^4.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -7762,6 +7753,22 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "focus-trap": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-5.1.0.tgz",
+      "integrity": "sha512-CkB/nrO55069QAUjWFBpX6oc+9V90Qhgpe6fBWApzruMq5gnlh90Oo7iSSDK7pKiV5ugG6OY2AXM5mxcmL3lwQ==",
+      "requires": {
+        "tabbable": "^4.0.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "tabbable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+          "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
+        }
       }
     },
     "follow-redirects": {
@@ -18064,6 +18071,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.4.tgz",
+      "integrity": "sha512-M1thgfxQ6NGuiSv6I+392zkDcyE5f0DbZPkUQaxnFNu9n9UR/GuE0ii2Hf3l7CQHNiraYhD8W3GBRp35W/+kXg=="
     },
     "table": {
       "version": "5.4.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "postcss-preset-env": "^6.7.0",
     "prismjs": "^1.19.0",
     "svgxuse": "^1.2.6",
+    "tabbable": "^5.1.4",
     "tailwindcss": "^1.2.0-canary.5",
     "tailwindcss-transitions": "^2.1.0",
     "tailwindcss-typography": "^2.2.0",


### PR DESCRIPTION
# Checklist (Only for frontend changes)
- [ ] Changes tested in IE11
- [ ] Responsive
- [ ] Documented "How to use it"
- [ ] Documented "How to install"
- [ ] Featured in Styleguide

# Summary of this PR

I got the error that `tabbable` wasn't installed, a dependency of focus-trap. Install it with this change.