### PR TITLE
Use generic gitlab-tasks.yml to avoid repetition in gitlab-ci.yml. Us…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,5 @@
+include: '.gitlab-tasks.yml'
+
 default:
   image: python:3.8
 
@@ -35,34 +37,22 @@ test-frontend:
 
 build-staging:
   stage: build-staging
-  image: docker:19.03.8
+  extends:
+    - .build-definition
   only:
       - develop
   variables:
-    DOCKER_DRIVER: overlay2
-  services:
-    - docker:18.09-dind
-  before_script:
-    - docker info
-  script:
-    - docker build --build-arg build_env=build-staging -t ${CI_REGISTRY}/${CI_PROJECT_PATH}:backend_staging backend/
-    - docker build --build-arg build_env=build-staging -t ${CI_REGISTRY}/${CI_PROJECT_PATH}:docs_staging docs/
-    - docker build --build-arg build_env=build-staging -t ${CI_REGISTRY}/${CI_PROJECT_PATH}:frontend_staging frontend/
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN ${CI_REGISTRY}
-    - docker push ${CI_REGISTRY}/${CI_PROJECT_PATH}:backend_staging
-    - docker push ${CI_REGISTRY}/${CI_PROJECT_PATH}:docs_staging
-    - docker push ${CI_REGISTRY}/${CI_PROJECT_PATH}:frontend_staging
-  tags:
-    - docker-privileged
+    ENVIRONMENT: staging
 
 deploy-staging:
   stage: deploy-staging
+  extends:
+    - .deploy-definition
+  only:
+    - develop
   environment:
     name: staging
-  script:
-    - scp -r ./deploy/ ${STAGING_USER}@${STAGING_DOMAIN}:/srv/app/
-    - ssh ${STAGING_USER}@$STAGING_DOMAIN "cd /srv/app/deploy/scripts/; ./deploy.sh ${CI_DEPLOY_USER} ${CI_DEPLOY_PASSWORD} ${CI_REGISTRY} ${CI_PROJECT_PATH} staging"
-  tags:
-    - shell
-  only:
-  - develop
+  variables:
+    DEPLOYMENT_TARGET_HOST: $STAGING_DOMAIN
+    DEPLOYMENT_SSH_KEY: $STAGING_SSH_PRIVATE_KEY
+    ENVIRONMENT: staging

--- a/.gitlab-tasks.yml
+++ b/.gitlab-tasks.yml
@@ -1,0 +1,38 @@
+# Build a docker image for frontend, backend and docs suffixed with the environment name
+# and push it to the gitlab container repository of this project
+.build-definition: &build-definition
+  image: docker:19.03.8
+  tags:
+    - docker-privileged
+  variables:
+    DOCKER_DRIVER: overlay2
+  services:
+    - docker:18.09-dind
+  before_script:
+    - docker info
+  script:
+    - docker build --build-arg build_env=build-${ENVIRONMENT} -t ${CI_REGISTRY}/${CI_PROJECT_PATH}:backend_${ENVIRONMENT} backend/
+    - docker build --build-arg build_env=build-${ENVIRONMENT} -t ${CI_REGISTRY}/${CI_PROJECT_PATH}:docs_${ENVIRONMENT} docs/
+    - docker build --build-arg build_env=build-${ENVIRONMENT} -t ${CI_REGISTRY}/${CI_PROJECT_PATH}:frontend_${ENVIRONMENT} frontend/
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN ${CI_REGISTRY}
+    - docker push ${CI_REGISTRY}/${CI_PROJECT_PATH}:backend_${ENVIRONMENT}
+    - docker push ${CI_REGISTRY}/${CI_PROJECT_PATH}:docs_${ENVIRONMENT}
+    - docker push ${CI_REGISTRY}/${CI_PROJECT_PATH}:frontend_${ENVIRONMENT}
+
+# Copy deploy folder to given target server and run deploy.sh.
+# Deploy SSH key is injected into gitlab docker runner.
+.deploy-definition: &deploy-definition
+  image: alpine:latest
+  tags:
+    - docker-privileged
+  before_script:
+    - apk add --no-cache rsync
+    - 'which ssh-agent || ( apk add --no-cache openssh-client )'
+    - eval $(ssh-agent -s)
+    - echo "$DEPLOYMENT_SSH_KEY" | tr -d '\r' | ssh-add -
+    - mkdir -p ~/.ssh
+    - '[[ -f /.dockerenv ]] && echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config'
+  script:
+    - ssh manager@${DEPLOYMENT_TARGET_HOST} "mkdir -p ~/srv/app/deploy"
+    - rsync -r ./deploy/* manager@${DEPLOYMENT_TARGET_HOST}:~/srv/app/
+    - ssh manager@${DEPLOYMENT_TARGET_HOST} "cd ~/srv/app/; ./scripts/deploy.sh ${CI_DEPLOY_USER} ${CI_DEPLOY_PASSWORD} ${CI_REGISTRY} ${CI_PROJECT_PATH} ${ENVIRONMENT}"


### PR DESCRIPTION
…e docker runner for deployments. Change app folder on server to manager user instead of root and create folder if it doesnt exist.

# Checklist (Only for frontend changes)
- [ ] Changes tested in IE11
- [ ] Responsive
- [ ] Documented "How to use it"
- [ ] Documented "How to install"
- [ ] Featured in Styleguide

# Summary of this PR
Add gitlab-tasks.yml which contains reusable anchors for building images and deploying. On its own this is a trivial change, but when used in a project it makes add build or deploy stages easy and less prone to error.

Some improvements were also included:
- When deploying "/home/root/srv/app" is no longer used as the parent directory for the app, /home/manager/srv/app is used instead. This means the deploy script can create the folder if it doesnt exist.
- ~/srv/app will be auto created if it doesnt exist (simplifies server setup)
- A docker runner is now used to deploy. Shell runers are too slow. This means a deployment SSH key will have to be provided for each server.