### PR TITLE
fix: remove view name to not cause next tick error

### DIFF
--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -8,7 +8,6 @@
 import Login from '@/components/Login.vue';
 
 export default {
-  name: 'Login',
   components: {
     Login,
   },

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -8,6 +8,7 @@
 import Login from '@/components/Login.vue';
 
 export default {
+  name: 'LoginView',
   components: {
     Login,
   },


### PR DESCRIPTION
# Checklist (Only for frontend changes)
- [ ] Changes tested in IE11
- [ ] Responsive
- [ ] Documented "How to use it"
- [ ] Documented "How to install"
- [ ] Featured in Styleguide

# Summary of this PR
Giving the View and the Component loaded in the view the same name can cause the following error:
`[Vue warn]: Error in nextTick: "RangeError: Maximum call stack size exceeded"`
so this should prevent it to happen.